### PR TITLE
Statistics - types

### DIFF
--- a/src/scripts/types/types.ts
+++ b/src/scripts/types/types.ts
@@ -71,14 +71,38 @@ export type TWordDifficulty = 'unset' | 'hard' | 'known';
 
 export interface IUserWord {
   difficulty: TWordDifficulty;
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  optional?: {};
+  optional?: {
+    faced?: 'yes';
+    countTowardsKnown?: number;
+    totalCountRight?: number;
+    totalCountWrong?: number;
+  };
 }
 
 export interface IUserStatistics {
-  learnedWords: number;
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  optional: {};
+  learnedWords?: number;
+  optional?: {
+    statistics: IOneDayStatistics[];
+  };
+}
+
+export interface IGameStatistics {
+  newWordsCount: number;
+  percentRight: number;
+  longestStreak: number;
+}
+
+export interface IGeneralStatistics {
+  newWordsCount: number;
+  percentRight: number;
+  knownWordsCount: number;
+}
+
+export interface IOneDayStatistics {
+  date: string;
+  audiocall?: IGameStatistics;
+  sprint?: IGameStatistics;
+  general: IGeneralStatistics;
 }
 
 export interface IUserSettings {


### PR DESCRIPTION
Предлагаю обсудить статистику.

В конце раунда каждой игры в модуль статистики будут отправляться 2 массива: один со словами, на которые были даны верные ответы, второй - с неверными.

Каждое слово обрабатывается и  обновляется статистика по конкретному слову в IUserWord. Делаем createUserWord или updateUserWord через АПИ. Свойство faced указывается однократно, если его еще не было. Это значит, что слово встретилось впервые. countTowardsKnown считает сколько дано правильных ответов подряд. Если юзер ошибся, обнуляется. Если достигло 3, слово становится 'known'. 
Если слово было 'known', а пользователь ошибся, слово становится 'unset' (в difficulty нельзя записать пустую строку и удалить это свойство тоже. Не знаю, как сделать по-другому)

IGameStatistics - статистика по игре за день, IGeneralStatistics - общая статистика по играм за день. Обновляются после каждого раунда игры и входят в IOneDayStatistics. В IOneDayStatistics указывается дата (день - месяц - год) и статистика по играм в общем и по отдельности.

Долгосрочная статистика (IUserStatistics)  - массив из IOneDayStatistics. На основании данных массива строятся два графика:  график, отображающий количество новых слов за каждый день изучения, и график, отображающий увеличение общего количества изученных слов за весь период обучения по дням.

Вопросы, предложения, замечания?)))